### PR TITLE
Move PrivacyLabelRedact to ATC-DE coding slices; update example

### DIFF
--- a/src/fhir/fsh-generated/resources/MedicationDispense-ExampleEPAMedicationDispenseMaaloxan.json
+++ b/src/fhir/fsh-generated/resources/MedicationDispense-ExampleEPAMedicationDispenseMaaloxan.json
@@ -23,7 +23,7 @@
     },
     {
       "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-MedicationDispense.renderedDosageInstruction",
-      "valueMarkdown": "1-0-0-0 Stück"
+      "valueMarkdown": "Morgens 1 Tablette einnehmen, mit etwas Wasser."
     },
     {
       "url": "http://ig.fhir.de/igs/medication/StructureDefinition/GeneratedDosageInstructionsMeta",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-epa-research-medication.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-epa-research-medication.json
@@ -1324,20 +1324,6 @@
       },
       {
         "id": "Medication.code.coding",
-        "extension": [
-          {
-            "extension": [
-              {
-                "url": "obligationPolicy",
-                "valueCoding": {
-                  "code": "REDACT",
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
-                }
-              }
-            ],
-            "url": "https://gematik.de/fhir/epa-research/StructureDefinition/privacy-label-extension"
-          }
-        ],
         "path": "Medication.code.coding",
         "slicing": {
           "discriminator": [
@@ -1393,6 +1379,20 @@
       },
       {
         "id": "Medication.code.coding:atc-de",
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "obligationPolicy",
+                "valueCoding": {
+                  "code": "REDACT",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                }
+              }
+            ],
+            "url": "https://gematik.de/fhir/epa-research/StructureDefinition/privacy-label-extension"
+          }
+        ],
         "path": "Medication.code.coding",
         "sliceName": "atc-de",
         "short": "Code defined by a terminology system",
@@ -3392,20 +3392,6 @@
       },
       {
         "id": "Medication.ingredient.item[x]:itemCodeableConcept.coding",
-        "extension": [
-          {
-            "extension": [
-              {
-                "url": "obligationPolicy",
-                "valueCoding": {
-                  "code": "REDACT",
-                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
-                }
-              }
-            ],
-            "url": "https://gematik.de/fhir/epa-research/StructureDefinition/privacy-label-extension"
-          }
-        ],
         "path": "Medication.ingredient.item[x].coding",
         "slicing": {
           "discriminator": [
@@ -3461,6 +3447,20 @@
       },
       {
         "id": "Medication.ingredient.item[x]:itemCodeableConcept.coding:atc-de",
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "obligationPolicy",
+                "valueCoding": {
+                  "code": "REDACT",
+                  "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode"
+                }
+              }
+            ],
+            "url": "https://gematik.de/fhir/epa-research/StructureDefinition/privacy-label-extension"
+          }
+        ],
         "path": "Medication.ingredient.item[x].coding",
         "sliceName": "atc-de",
         "short": "Code defined by a terminology system",
@@ -4298,6 +4298,19 @@
       },
       {
         "id": "Medication.code.coding",
+        "path": "Medication.code.coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "$this"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Medication.code.coding:atc-de",
         "extension": [
           {
             "extension": [
@@ -4312,19 +4325,6 @@
             "url": "https://gematik.de/fhir/epa-research/StructureDefinition/privacy-label-extension"
           }
         ],
-        "path": "Medication.code.coding",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "$this"
-            }
-          ],
-          "rules": "open"
-        }
-      },
-      {
-        "id": "Medication.code.coding:atc-de",
         "path": "Medication.code.coding",
         "sliceName": "atc-de",
         "min": 0,
@@ -4470,6 +4470,19 @@
       },
       {
         "id": "Medication.ingredient.item[x]:itemCodeableConcept.coding",
+        "path": "Medication.ingredient.item[x].coding",
+        "slicing": {
+          "discriminator": [
+            {
+              "type": "value",
+              "path": "$this"
+            }
+          ],
+          "rules": "open"
+        }
+      },
+      {
+        "id": "Medication.ingredient.item[x]:itemCodeableConcept.coding:atc-de",
         "extension": [
           {
             "extension": [
@@ -4484,19 +4497,6 @@
             "url": "https://gematik.de/fhir/epa-research/StructureDefinition/privacy-label-extension"
           }
         ],
-        "path": "Medication.ingredient.item[x].coding",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "$this"
-            }
-          ],
-          "rules": "open"
-        }
-      },
-      {
-        "id": "Medication.ingredient.item[x]:itemCodeableConcept.coding:atc-de",
         "path": "Medication.ingredient.item[x].coding",
         "sliceName": "atc-de",
         "min": 0,

--- a/src/fhir/input/fsh/examples/ExampleEPAMedicationDispenseMaaloxan.fsh
+++ b/src/fhir/input/fsh/examples/ExampleEPAMedicationDispenseMaaloxan.fsh
@@ -6,7 +6,7 @@ Description: "Full Maaloxan MedicationDispense — pre-redaction reference."
 
 // Explicitly defined extension slices are copied; others are filtered out.
 * extension[rxPrescriptionProcessIdentifier].valueIdentifier.value = "160.100.000.000.010.12_20251027"
-* extension[renderedDosageInstruction].valueMarkdown = "1-0-0-0 Stück"
+* extension[renderedDosageInstruction].valueMarkdown = "Morgens 1 Tablette einnehmen, mit etwas Wasser."
 * extension[generatedDosageInstructionsMeta]
   * extension[algorithmVersion].valueString = "1.0.1"
   * extension[language].valueCode = #de-DE

--- a/src/fhir/input/fsh/profiles/EPAResearchMedication.fsh
+++ b/src/fhir/input/fsh/profiles/EPAResearchMedication.fsh
@@ -12,6 +12,8 @@ Description: "Pseudonymisiertes Gegenstück zu EPAMedication für den ePA-Forsch
 * code.coding ^slicing.rules = #open
 
 * code.coding contains atc-de 0..0
+// Convention: attach PrivacyLabel to the slice itself
+* code.coding[atc-de]
   * insert PrivacyLabelRedact
 * code.coding[atc-de].system = "http://fhir.de/CodeSystem/bfarm/atc"
 
@@ -38,6 +40,7 @@ Description: "Pseudonymisiertes Gegenstück zu EPAMedication für den ePA-Forsch
 * ingredient.itemCodeableConcept.coding ^slicing.rules = #open
 
 * ingredient.itemCodeableConcept.coding contains atc-de 0..0
+* ingredient.itemCodeableConcept.coding[atc-de]
   * insert PrivacyLabelRedact
 * ingredient.itemCodeableConcept.coding[atc-de].system = "http://fhir.de/CodeSystem/bfarm/atc"
 


### PR DESCRIPTION
Replace the Maaloxan example rendered dosage instruction with a natural-language German instruction.

Please go the the `Preview` tab and select the appropriate sub-template:

[**Contributor PR**](?expand=1&template=PR_Template_Contributor.md)

[Version Upgrade **(for Admins)**](?expand=1&template=PR_Template_VersionUpgrade.md)


<!--- If you have no idea, time, what so ever, you can also continue here without using a pull request template-->
<!--- Please keep in mind that if you use this short cut, your PR is lees likely to be merged, because of missing information.-->
## Pull Request Short Cut
<!--- Describe your changes briefly. If you need some space to describe, please use the contributor template as mentioned at the top-->